### PR TITLE
Implements the floating bus effect

### DIFF
--- a/core/display.js
+++ b/core/display.js
@@ -105,10 +105,12 @@ JSSpeccy.Display = function(opts) {
 			pixels[imageDataPos++] = color;
 			pixels[imageDataPos++] = color;
 			pixels[imageDataPos++] = color;
+			memory.floatingBus = 255;
 		} else {
 			/* main screen area */
 			var pixelByte = memory.readScreen( pixelLineAddress | beamX );
 			var attributeByte = memory.readScreen( attributeLineAddress | beamX );
+			memory.floatingBus = attributeByte;
 			
 			var inkColor, paperColor;
 			if ( (attributeByte & 0x80) && (flashPhase & 0x10) ) {

--- a/core/io_bus.js
+++ b/core/io_bus.js
@@ -18,7 +18,7 @@ JSSpeccy.IOBus = function(opts) {
 			/* kempston joystick */
 			return 0;
 		} else {
-			return 0xff;
+			return memory.floatingBus;
 		}
 	};
 	self.write = function(addr, val, tstates) {

--- a/core/memory.js
+++ b/core/memory.js
@@ -6,6 +6,8 @@ JSSpeccy.Memory = function(opts) {
 
 	var noContentionTable = model.noContentionTable;
 	var contentionTable = model.contentionTable;
+	
+	var floatingBus = 255;
 
 	function MemoryPage(data, isContended) {
 		var self = {};


### PR DESCRIPTION
When reading an inexistent I/O port in the Sinclair Spectrum, the value read not always is 255. That only happens when the ULA is painting the BORDER. When painting the PAPER, the bus presents the current value being read by the ULA from the video memory.

This effect is used by some games to synchronize with the beam. They can use a naive way, by just waiting for a non-255 value to appear in the bus, thus knowing that now the beam has started painting the PAPER, or checking that value and waiting for an specific one (usually a color attribute value), thus being able to detect when an specific line is being painted.

This patch emulates this behavior, thus allowing these games to run in the emulator.

Tested with Escape from M.O.N.J.A.S. (https://www.rastersoft.com/programas/monjas.html )

Fixes https://github.com/gasman/jsspeccy2/issues/14